### PR TITLE
Make n optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function knn(tree, queryPoint, n, predicate) {
             var candidate = queue.pop().node;
             if (!predicate || predicate(candidate))
                 result.push(candidate);
-            if (result.length === n) return result;
+            if (n && result.length === n) return result;
         }
 
         node = queue.pop();


### PR DESCRIPTION
If we want an unbounded search starting from an initial position that fulfil the predicate, we can call the search like this.

`knn(graph, [x,y], undefined, function (node) { return node.name === 'blubb' }`
