### PR TITLE
doc: fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ _k_-nearest neighbors search for [RBush](https://github.com/mourner/rbush).
 Implements a simple depth-first kNN search algorithm using a priority queue.
 
 ```js
-var rbush = require('rbush');
+var RBush = require('rbush');
 var knn = require('rbush-knn');
 
-var tree = rbush().load(data); // create an RBush index
+var tree = new RBush(); // create RBush tree
+tree.load(data); // bulk insert
 var neighbors = knn(tree, 40, 40, 10); // return 10 nearest items around point [40, 40]
 ```
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint-config-mourner": "^2.0.3",
     "rbush": "^2.0.2",
     "tape": "^4.9.0",
-    "uglify-js": "^3.3.18"
+    "uglify-js": "~3.3.28"
   },
   "dependencies": {
     "tinyqueue": "^1.2.3"
@@ -38,8 +38,8 @@
     "extends": "mourner"
   },
   "files": [
-      "rbush-knn.js",
-      "rbush-knn.min.js"
+    "rbush-knn.js",
+    "rbush-knn.min.js"
   ],
   "repository": "mourner/rbush-knn"
 }


### PR DESCRIPTION
fixes example introduced in PR #12 

Took me some time to realise you have to instantiate `RBush`

Example suggests you can use it directly as a `function`...