### PR TITLE
require('tinyqueue').default

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Queue = require('tinyqueue');
+var Queue = require('tinyqueue').default;
 
 module.exports = knn;
 module.exports.default = knn;


### PR DESCRIPTION
`tinyqueue` no longer works with regular `require` making `rbush-knn` unusable in version 3.0.1