### PR TITLE
refactor: convert rbush-knn to es6 module

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -1,7 +1,5 @@
-'use strict';
-
-var rbush = require('rbush'),
-    knn = require('./');
+import RBush from 'rbush';
+import knn from './index';
 
 var N = 200000,
     M = 20000,
@@ -15,7 +13,7 @@ for (var i = 0; i < N; i++) {
 }
 
 console.time('load ' + N + ' points');
-var tree = rbush().load(points);
+var tree = new RBush().load(points);
 console.timeEnd('load ' + N + ' points');
 
 console.time('knn query ' + K + ' neighbors x ' + M);

--- a/index.js
+++ b/index.js
@@ -1,11 +1,6 @@
-'use strict';
+import Queue from 'tinyqueue';
 
-var Queue = require('tinyqueue');
-
-module.exports = knn;
-module.exports.default = knn;
-
-function knn(tree, x, y, n, predicate, maxDistance) {
+export default function knn(tree, x, y, n, predicate, maxDistance) {
     var node = tree.data,
         result = [],
         toBBox = tree.toBBox,

--- a/package.json
+++ b/package.json
@@ -2,14 +2,16 @@
   "name": "rbush-knn",
   "version": "3.0.1",
   "description": "k-neareset neighbors search for RBush",
-  "main": "index.js",
+  "main": "rbush-knn.js",
+  "module": "index.js",
+  "browser": "rbush-knn.min.js",
   "jsdelivr": "rbush-knn.min.js",
   "unpkg": "rbush-knn.min.js",
   "scripts": {
-    "test": "eslint index.js test.js bench.js && tape test.js",
-    "build": "browserify index.js -s knn -o rbush-knn.js",
-    "build-min": "browserify index.js -s knn | uglifyjs -c -m > rbush-knn.min.js",
-    "prepare": "npm run build && npm run build-min"
+    "bench": "node -r esm bench.js",
+    "test": "eslint index.js test.js bench.js && tape -r esm test.js",
+    "build": "rollup -c",
+    "prepare": "npm run build"
   },
   "keywords": [
     "rbush",
@@ -21,20 +23,26 @@
   "author": "Vladimir Agafonkin",
   "license": "ISC",
   "devDependencies": {
-    "browserify": "^16.5.0",
+    "@rollup/plugin-node-resolve": "^8.4.0",
     "eslint": "^6.8.0",
     "eslint-config-mourner": "^2.0.3",
+    "esm": "^3.2.25",
     "rbush": "^3.0.1",
-    "tape": "^4.13.2",
-    "uglify-js": "~3.8.0"
+    "rollup": "^2.23.0",
+    "rollup-plugin-terser": "^6.1.0",
+    "tape": "^4.13.2"
   },
   "dependencies": {
     "tinyqueue": "^2.0.3"
   },
   "eslintConfig": {
-    "extends": "mourner"
+    "extends": "mourner",
+    "parserOptions": {
+      "sourceType": "module"
+    }
   },
   "files": [
+    "index.js",
     "rbush-knn.js",
     "rbush-knn.min.js"
   ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,17 @@
+import { terser } from 'rollup-plugin-terser';
+import resolve from '@rollup/plugin-node-resolve';
+
+const output = (file, plugins) => ({
+    input: 'index.js',
+    output: {
+        name: 'rbush-knn',
+        format: 'umd',
+        file
+    },
+    plugins
+});
+
+export default [
+    output('rbush-knn.js', [resolve()]),
+    output('rbush-knn.min.js', [resolve(), terser()])
+];

--- a/test.js
+++ b/test.js
@@ -1,9 +1,7 @@
-'use strict';
+import RBush from 'rbush';
+import test from 'tape';
 
-var RBush = require('rbush');
-var test = require('tape');
-
-var knn = require('./');
+import knn from './index';
 
 function rbush() {
     return new RBush();


### PR DESCRIPTION
TL;DR
Convert `rbush-knn` to es6 module.

Would be nice to convert `rbush-knn` to es6, since `rbush` already has been converted to es6 for quite a while. (https://github.com/mourner/rbush/pull/89)

This is also fixes #18 .

Used the same setup for `npm build` as in https://github.com/mourner/rbush

Please let me know if you have any questions or concerns.